### PR TITLE
Fix Tor Browser version comparison

### DIFF
--- a/com.github.micahflee.torbrowser-launcher.yaml
+++ b/com.github.micahflee.torbrowser-launcher.yaml
@@ -120,6 +120,7 @@ modules:
           - use-correct-sys-prefix.patch
           - use-xdg-home-vars.patch
           - update-tor-browser-developers-public-key.patch
+          - use-better-version-string-comparison.patch
     build-commands:
       - "python3 setup.py install --prefix=/app --root=/ --optimize=1"
     post-install:

--- a/use-better-version-string-comparison.patch
+++ b/use-better-version-string-comparison.patch
@@ -1,0 +1,38 @@
+From 070a5f40af7c93d39bddfc5aa382469ce97dfd5b Mon Sep 17 00:00:00 2001
+From: Robert Sacks <robert@rmsacks.com>
+Date: Wed, 23 Sep 2020 00:42:50 -0400
+Subject: [PATCH] Use better version string comparison
+
+Currently, this function compares raw version strings such as "7.5.2"
+and "9.6" to find the newer version. This worked fine until Tor Browser
+version 10 was released and "10.0" is no longer considered larger than
+"7.5.2" by this function. This commit changes the function to split the
+raw strings on periods and compares the corresponding tuples, such as
+(7, 5, 2) and (10, 0). While this does not cover all edge cases, it
+should work better for these purposes. It is also simple and avoids
+adding an extra dependency compared to other options.
+
+Fixes #498
+---
+ torbrowser_launcher/launcher.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/torbrowser_launcher/launcher.py b/torbrowser_launcher/launcher.py
+index efcd1c8..715ef20 100644
+--- a/torbrowser_launcher/launcher.py
++++ b/torbrowser_launcher/launcher.py
+@@ -417,7 +417,10 @@ class Launcher(QtWidgets.QMainWindow):
+                 installed_version = line.split()[2].decode()
+                 break
+ 
+-        if self.min_version <= installed_version:
++        def version_tuple(v):
++            return tuple(map(int, v.split(".")))
++
++        if version_tuple(self.min_version) <= version_tuple(installed_version):
+             return True
+ 
+         return False
+-- 
+2.25.1
+


### PR DESCRIPTION
Broken since Tor Browser 10.0 release. Apply fix from [upstream PR](https://github.com/micahflee/torbrowser-launcher/pull/499). 