### PR TITLE
Enable Wayland support

### DIFF
--- a/com.github.micahflee.torbrowser-launcher.yaml
+++ b/com.github.micahflee.torbrowser-launcher.yaml
@@ -11,7 +11,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --device=dri
   - --socket=pulseaudio
   - --filesystem=xdg-download

--- a/com.github.micahflee.torbrowser-launcher.yaml
+++ b/com.github.micahflee.torbrowser-launcher.yaml
@@ -10,10 +10,12 @@ rename-icon: torbrowser
 finish-args:
   - --share=ipc
   - --share=network
+  - --socket=wayland
   - --socket=x11
   - --device=dri
   - --socket=pulseaudio
   - --filesystem=xdg-download
+  - --env=MOZ_ENABLE_WAYLAND=1
 modules:
   - shared-modules/dbus-glib/dbus-glib-0.110.json
 


### PR DESCRIPTION
Tor Browser seems to be running just fine under Wayland and I think this should be enabled by default for security reasons. We certainly don't want other XWayland apps being able to willy nilly see what a user is doing on Tor.

Closes #18.