### PR TITLE
Add libnotify support, update (some) dependencies

### DIFF
--- a/com.github.micahflee.torbrowser-launcher.yaml
+++ b/com.github.micahflee.torbrowser-launcher.yaml
@@ -29,8 +29,8 @@ modules:
       - /bin
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/fb/50/005826d31d58a7b90585b5510f2f597c5406ae34df884f4f5d63abfb6ca7/setuptools-62.3.3.tar.gz
-        sha256: e7d11f3db616cda0751372244c2ba798e8e56a28e096ec4529010b803485f3fe
+        url: https://files.pythonhosted.org/packages/dc/73/88920663229023b724a854d1ab7e3e50a1a28b63eeec399a604ba30f9242/setuptools-62.6.0.tar.gz
+        sha256: 990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741
         x-checker-data:
           type: pypi
           name: setuptools
@@ -136,20 +136,32 @@ modules:
         requests
     sources:
       - type: file
+        url: https://files.pythonhosted.org/packages/dc/73/88920663229023b724a854d1ab7e3e50a1a28b63eeec399a604ba30f9242/setuptools-62.6.0.tar.gz
+        sha256: 990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741
+        x-checker-data:
+          type: pypi
+          name: setuptools
+      - type: file
+        url: https://files.pythonhosted.org/packages/c0/6c/9f840c2e55b67b90745af06a540964b73589256cb10cc10057c87ac78fc2/wheel-0.37.1.tar.gz
+        sha256: e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4
+        x-checker-data:
+          type: pypi
+          name: wheel
+      - type: file
         url: https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz
         sha256: 9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
         x-checker-data:
           type: pypi
           name: idna
       - type: file
-        url: https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz
-        sha256: 68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61
+        url: https://files.pythonhosted.org/packages/e9/23/384d9953bb968731212dc37af87cb75a885dc48e0615bd6a303577c4dc4b/requests-2.28.0.tar.gz
+        sha256: d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b
         x-checker-data:
           type: pypi
           name: requests
       - type: file
-        url: https://files.pythonhosted.org/packages/07/10/75277f313d13a2b74fc56e29239d5c840c2bf09f17bf25c02b35558812c6/certifi-2022.5.18.1.tar.gz
-        sha256: 9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7
+        url: https://files.pythonhosted.org/packages/cc/85/319a8a684e8ac6d87a1193090e06b6bbb302717496380e225ee10487c888/certifi-2022.6.15.tar.gz
+        sha256: 84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d
         x-checker-data:
           type: pypi
           name: certifi
@@ -166,8 +178,8 @@ modules:
           type: pypi
           name: charset-normalizer
       - type: file
-        url: https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz
-        sha256: 0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
+        url: https://files.pythonhosted.org/packages/31/a2/12c090713b3d0e141f367236d3a8bdc3e5fca0d83ff3647af4892c16c205/chardet-5.0.0.tar.gz
+        sha256: 0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa
         x-checker-data:
           type: pypi
           name: chardet

--- a/com.github.micahflee.torbrowser-launcher.yaml
+++ b/com.github.micahflee.torbrowser-launcher.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
+  - --talk-name=org.freedesktop.Notifications
   - --device=dri
   - --socket=pulseaudio
   - --filesystem=xdg-download
@@ -224,6 +225,23 @@ modules:
           type: pypi
           name: distro
           packagetype: bdist_wheel
+
+  - name: libnotify
+    buildsystem: meson
+    config-opts:
+      - -Dtests=false
+      - -Dintrospection=disabled
+      - -Dman=false
+      - -Dgtk_doc=false
+      - -Ddocbook_docs=disabled
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.12.tar.xz
+        sha256: 744b2b37508135f8261b755a9debe6e09add421adc75bde930f6e198b70ab46e
+        x-checker-data:
+          type: anitya
+          project-id: 13149
+          url-template: https://download.gnome.org/sources/libnotify/$major.$minor/libnotify-$version.tar.xz
 
   - name: torbrowser-launcher
     buildsystem: simple


### PR DESCRIPTION
This pull request adds libnotify support, which should close #42. I've built and tested it locally and it seems to work as expected. It also updates some dependencies. It seems as requests most be updated before charset-normalizer can be bumped to version 2.1.0, please see psf/requests#6169. I've not been able to build the newest version of PyQt5 locally. It seems as the Flathub builder has the same problem.